### PR TITLE
Fatal error: Uncaught Exception: Repository class override

### DIFF
--- a/App/Post.php
+++ b/App/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+use Tarantool\Mapper\Entity;
+
+class Post extends Entity
+{
+    /**
+     * @var integer
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $title;
+}

--- a/App/PostRepository.php
+++ b/App/PostRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+use Tarantool\Mapper\Repository;
+
+class PostRepository extends Repository
+{
+    public $engine = 'memtx'; // or vinyl
+
+    public $indexes = [
+        ['id'],
+        [
+            'fields' => ['id'],
+            'unique' => true,
+        ],
+    ];
+}

--- a/App/index.php
+++ b/App/index.php
@@ -1,0 +1,32 @@
+<?php
+
+use Tarantool\Mapper\Plugin\Annotation;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+require 'Post.php';
+require 'PostRepository.php';
+
+$client = \Tarantool\Client\Client::fromDsn('tcp://tarantool');
+$mapper = new \Tarantool\Mapper\Mapper($client);
+$mapper->getPlugin(Tarantool\Mapper\Plugin\Sequence::class); // just not to fill id manually
+function AutoMigration(\Tarantool\Mapper\Mapper $mapper)
+{
+    /** @var Annotation $plugin */
+    $plugin = $mapper->getPlugin(Tarantool\Mapper\Plugin\Annotation::class);
+    $plugin->setRepositoryPostfix('Repository')
+        ->register(Post::class)
+        ->register(PostRepository::class)
+        ->migrate();
+}
+function AutoAssociation(\Tarantool\Mapper\Mapper $mapper)
+{
+    /** @var Tarantool\Mapper\Plugin\UserClasses $userClasses */
+    $userClasses = $mapper->getPlugin(Tarantool\Mapper\Plugin\UserClasses::class);
+    $userClasses->mapEntity('post', Post::class);
+    $userClasses->mapRepository('post', PostRepository::class);
+}
+AutoMigration($mapper);
+AutoAssociation($mapper);
+$nekufa = $mapper->create('post', ['title' => 'dmitry2', 'slug' => 'slug2']);
+

--- a/HOW_TO_REPEAT_A_PROBLEM.md
+++ b/HOW_TO_REPEAT_A_PROBLEM.md
@@ -1,0 +1,23 @@
+docker-compose up -d
+
+docker-compose exec -it mapper_php_1 bash
+
+apt update
+apt install -y git
+
+curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin \
+ && mv /usr/bin/composer.phar /usr/bin/composer
+
+composer install -o
+
+php App/index.php
+
+```
+Fatal error: Uncaught Exception: Repository class override in /app/src/Space.php:524
+Stack trace:
+#0 /app/src/Mapper.php(108): Tarantool\Mapper\Space->getRepository()
+#1 /app/src/Mapper.php(45): Tarantool\Mapper\Mapper->getRepository('post')
+#2 /app/App/index.php(49): Tarantool\Mapper\Mapper->create('post', Array)
+#3 {main}
+  thrown in /app/src/Space.php on line 524
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.3'
+
+services:
+  php:
+    image: php:7.4.2-fpm-buster
+    working_dir: /app
+    volumes:
+      - ./:/app
+
+  tarantool:
+    image: tarantool/tarantool:2.2.1
+    ports:
+      - 3302:3301


### PR DESCRIPTION
Добрый день коллеги, следуя README.md поймал ошибку:
```
Fatal error: Uncaught Exception: Repository class override in /app/src/Space.php:524
Stack trace:
#0 /app/src/Mapper.php(108): Tarantool\Mapper\Space->getRepository()
#1 /app/src/Mapper.php(45): Tarantool\Mapper\Mapper->getRepository('post')
#2 /app/App/index.php(49): Tarantool\Mapper\Mapper->create('post', Array)
#3 {main}
  thrown in /app/src/Space.php on line 524
```
Подскажите пожалуйста, что делаю не так.

Ошибка повторяется легко - см. файл HOW_TO_REPEAT_A_PROBLEM.md

Бранчевался от 4.5.18