### PR TITLE
A boolean field is not created

### DIFF
--- a/App/Post.php
+++ b/App/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+use Tarantool\Mapper\Entity;
+
+class Post extends Entity
+{
+    /**
+     * @var integer
+     */
+    public $id;
+
+    /**
+     * @var bool
+     */
+    public $title;
+}

--- a/App/PostRepository.php
+++ b/App/PostRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+use Tarantool\Mapper\Repository;
+
+class PostRepository extends Repository
+{
+    public $engine = 'memtx'; // or vinyl
+
+    public $indexes = [
+        ['id'],
+        [
+            'fields' => ['id'],
+            'unique' => true,
+        ],
+    ];
+}

--- a/App/index.php
+++ b/App/index.php
@@ -1,0 +1,23 @@
+<?php
+
+use Tarantool\Mapper\Plugin\Annotation;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+require 'Post.php';
+require 'PostRepository.php';
+
+$client = \Tarantool\Client\Client::fromDsn('tcp://tarantool');
+$mapper = new \Tarantool\Mapper\Mapper($client);
+$mapper->getPlugin(Tarantool\Mapper\Plugin\Sequence::class); // just not to fill id manually
+function AutoMigration(\Tarantool\Mapper\Mapper $mapper)
+{
+    /** @var Annotation $plugin */
+    $plugin = $mapper->getPlugin(Tarantool\Mapper\Plugin\Annotation::class);
+    $plugin->setRepositoryPostfix('Repository')
+        ->register(Post::class)
+        ->register(PostRepository::class)
+        ->migrate();
+}
+AutoMigration($mapper);
+$nekufa = $mapper->create('post', ['title' => true]);

--- a/HOW_TO_REPEAT_A_PROBLEM.md
+++ b/HOW_TO_REPEAT_A_PROBLEM.md
@@ -1,0 +1,24 @@
+docker-compose up -d
+
+docker-compose exec -it mapper_php_1 bash
+
+apt update
+apt install -y git
+
+curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin \
+ && mv /usr/bin/composer.phar /usr/bin/composer
+
+composer install -o
+
+php App/index.php
+
+unix/:/var/run/tarantool/tarantool.sock> box.space.post:format()
+---
+- [{'type': 'unsigned', 'name': 'id', 'is_nullable': false}, {'type': 'string', 'name': 'title',
+    'is_nullable': true}]
+...
+
+unix/:/var/run/tarantool/tarantool.sock> box.space.post:select()
+---
+- - [4, '1']
+...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.3'
+
+services:
+  php:
+    image: php:7.4.2-fpm-buster
+    working_dir: /app
+    volumes:
+      - ./:/app
+
+  tarantool:
+    image: tarantool/tarantool:2.2.1
+    ports:
+      - 3302:3301


### PR DESCRIPTION
Hi, guys.
Can you tell me, why mapper creates a string field instead of boolean. 
Look at the file App/Post.php
My variable $title has the annotaion @var bool
But, after runing php App/index.php you can see:
```
unix/:/var/run/tarantool/tarantool.sock> box.space.post:format()
---
- [{'type': 'unsigned', 'name': 'id', 'is_nullable': false}, {'type': 'string', 'name': 'title',
    'is_nullable': true}]
...

unix/:/var/run/tarantool/tarantool.sock> box.space.post:select()
---
- - [4, '1']
...
```
Look at file HOW_TO_REPEAT_A_PROBLEM.md for more details.

I think the problem can be in \Tarantool\Mapper\Plugin\Annotation::getTarantoolType()

So, how I can create a boolean field.